### PR TITLE
Added WEBROOT to websso origin url

### DIFF
--- a/openstack_auth/views.py
+++ b/openstack_auth/views.py
@@ -61,7 +61,7 @@ def login(request, template_name=None, extra_context=None, **kwargs):
         protocol = request.POST.get('auth_type', 'credentials')
         if utils.is_websso_enabled() and protocol != 'credentials':
             region = request.POST.get('region')
-            origin = utils.build_absolute_uri(request, '/auth/websso/')
+            origin = utils.build_absolute_uri(request, '%sauth/websso/' % settings.WEBROOT)
             url = ('%s/auth/OS-FEDERATION/websso/%s?origin=%s' %
                    (region, protocol, origin))
             return shortcuts.redirect(url)


### PR DESCRIPTION
Correct websso origin url in case of dashboard not on / but on different WEBROOT.
The general case is when dashboard answers at http://{HOST_IP}/dashboard, in this case the origin url must be http://{HOST_IP}/dashboard/auth/websso and not http://{HOST_IP}/auth/websso.