### PR TITLE
Fix bug for logout from firefox

### DIFF
--- a/openstack_auth/views.py
+++ b/openstack_auth/views.py
@@ -145,6 +145,7 @@ def websso(request):
     return django_http.HttpResponseRedirect(settings.LOGIN_REDIRECT_URL)
 
 
+@never_cache
 def logout(request, login_url=None, **kwargs):
     """Logs out the user if he is logged in. Then redirects to the log-in page.
 


### PR DESCRIPTION
Logout is redirected to login because its cached.

Removed caching in logout view.
